### PR TITLE
Enable specifying the value for dcterms:modified value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>
         <kemitix-tiles.version>2.8.0</kemitix-tiles.version>
+        <assertj.version>3.22.0</assertj.version>
         <lombok.version>1.18.20</lombok.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-io.version>2.10.0</commons-io.version>
@@ -62,7 +63,12 @@
             <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
-
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,8 @@
         <relativePath/>
     </parent>
 
-    <groupId>net.kemitix</groupId>
     <artifactId>epub-creator</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     
     <scm>
         <connection>scm:git:git@github.com:kemitix/epub-creator.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,9 @@
         <relativePath/>
     </parent>
 
+    <groupId>net.kemitix</groupId>
     <artifactId>epub-creator</artifactId>
-    <version>1.2.0</version>
+    <version>1.1.0</version>
     
     <scm>
         <connection>scm:git:git@github.com:kemitix/epub-creator.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -26,35 +26,40 @@
 
         <tiles-maven-plugin.version>2.22</tiles-maven-plugin.version>
         <kemitix-tiles.version>2.8.0</kemitix-tiles.version>
+        <lombok.version>1.18.20</lombok.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-io.version>2.10.0</commons-io.version>
+        <htmlcleaner.version>2.24</htmlcleaner.version>
+        <junit.version>4.13.2</junit.version>
     </properties>
     
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.htmlcleaner</groupId>
             <artifactId>htmlcleaner</artifactId>
-            <version>2.24</version>
+            <version>${htmlcleaner.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.10.0</version>
+            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
-            <version>3.2.2</version>
+            <version>${commons-collections.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/coza/opencollab/epub/creator/impl/OpfCreatorDefault.java
+++ b/src/main/java/coza/opencollab/epub/creator/impl/OpfCreatorDefault.java
@@ -36,6 +36,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Default implementation of the OpfCreator. This follows EPUB3 standards to
@@ -121,7 +122,18 @@ public class OpfCreatorDefault implements OpfCreator {
         addNodeData(metaNode, "dc:identifier", book.getId());
         addNodeData(metaNode, "dc:title", book.getTitle());
         addNodeData(metaNode, "dc:language", book.getLanguage());
-        addNodeData(metaNode, "meta", new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'").format(new Date()));
+        Optional<MetadataItem> customModifiedValue = metadataItems.stream()
+                .filter(MetadataItem::hasValue)
+                .filter(MetadataItem::hasProperty)
+                .filter(item -> item.getProperty().equals("dcterms:modified"))
+                .findFirst();
+        if (customModifiedValue.isPresent()) {
+            MetadataItem item = customModifiedValue.get();
+            addNodeData(metaNode, "meta", item.getValue());
+            metadataItems.remove(item);
+        } else {
+            addNodeData(metaNode, "meta", new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss'Z'").format(new Date()));
+        }
         if (book.getAuthor() != null) {
             TagNode creatorNode = new TagNode("dc:creator");
             creatorNode.addChild(new ContentNode(book.getAuthor()));

--- a/src/test/java/coza/opencollab/epub/creator/EpubCreatorTest.java
+++ b/src/test/java/coza/opencollab/epub/creator/EpubCreatorTest.java
@@ -2,47 +2,85 @@ package coza.opencollab.epub.creator;
 
 import coza.opencollab.epub.creator.api.MetadataItem;
 import coza.opencollab.epub.creator.model.EpubBook;
-import java.io.File;
-import java.io.FileOutputStream;
-import junit.framework.Assert;
+import lombok.SneakyThrows;
+import lombok.val;
 import org.apache.commons.io.IOUtils;
+import org.assertj.core.api.WithAssertions;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Scanner;
+import java.util.zip.ZipFile;
+
 /**
- *
  * @author OpenCollab
  */
-public class EpubCreatorTest {
+public class EpubCreatorTest implements WithAssertions {
+
+    String author = "Samuel Holtzkampf";
+    String modified = "modified-date-and-time";
 
     @Test
-    public void testEpubCreate() {
-        try (FileOutputStream file = new FileOutputStream(new File("test.epub"))) {
-            EpubBook book = new EpubBook("en", "Samuel .-__Id1", "Samuel Test Book", "Samuel Holtzkampf");
+    public void bookHasAuthor() {
+        //when
+        val book = createEpubBook();
+        //then
+        assertThat(book.getAuthor()).isEqualTo(author);
 
-            MetadataItem.Builder builder = MetadataItem.builder();
-            book.addMetadata(builder.name("dc:creator").value("Bob Smith"));
-            book.addMetadata(builder.name("meta")
-                    .property("role").refines("#editor-id")
-                    .value("Editor"));
+    }
 
-            book.addContent(this.getClass().getResourceAsStream("/epub30-overview.xhtml"),
-                    "application/xhtml+xml", "xhtml/epub30-overview.xhtml", true, true).setId("Overview");
-            book.addContent(this.getClass().getResourceAsStream("/idpflogo_web_125.jpg"),
-                    "image/jpeg", "img/idpflogo_web_125.jpg", false, false);
-            book.addContent(this.getClass().getResourceAsStream("/epub-spec.css"),
-                    "text/css", "css/epub-spec.css", false, false);
-            book.addTextContent("TestHtml", "xhtml/samuelTest2.xhtml", "Samuel test one two four!!!!!\nTesting two").setToc(true);
-            book.addTextContent("TestHtml", "xhtml/samuelTest.xhtml", "Samuel test one two three\nTesting two").setToc(true);
-            book.addCoverImage(IOUtils.toByteArray(this.getClass().getResourceAsStream("/P1010832.jpg")),
-                    "image/jpeg", "images/P1010832.jpg");
+    @Test
+    public void hasSetModifiedValue() {
+        //given
+        //TODO use a proper temp file
+        val file = new File("test.epub");
+        writeBookToFile(createEpubBook(), file);
+        //when
+        String bookOpf = unzipFileEntry(file, "content/book.opf");
+        //then
+        assertThat(bookOpf).contains(String.format("<meta property=\"dcterms:modified\">%s</meta>", modified));
+    }
 
-
-            book.writeToStream(file);
-            // TODO : real tests to see if document correct, this is just to test that creation is succesfull
-            Assert.assertEquals("test", "test");
-        } catch (Exception ex) {
-            System.out.println(ex);
-            Assert.assertEquals("test", "test1");
+    @SneakyThrows
+    private String unzipFileEntry(File file, String name) {
+        val zipFile = new ZipFile(file);
+        val entry = zipFile.getEntry(name);
+        val inputStream = zipFile.getInputStream(entry);
+        try (Scanner scanner = new Scanner(inputStream)) {
+            return scanner.useDelimiter("\\A").next();
         }
+    }
+
+    @SneakyThrows
+    private void writeBookToFile(EpubBook book, File file) {
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+            book.writeToStream(outputStream);
+        }
+    }
+
+    @SneakyThrows
+    private EpubBook createEpubBook() {
+        EpubBook book = new EpubBook("en", "Samuel .-__Id1", "Samuel Test Book", author);
+
+        MetadataItem.Builder builder = MetadataItem.builder();
+        book.addMetadata(builder.name("dc:creator").value("Bob Smith"));
+        book.addMetadata(builder.name("meta")
+                .property("role").refines("#editor-id")
+                .value("Editor"));
+        book.addMetadata((builder.name("meta").property("dcterms:modified").value(modified)));
+
+        book.addContent(this.getClass().getResourceAsStream("/epub30-overview.xhtml"),
+                "application/xhtml+xml", "xhtml/epub30-overview.xhtml", true, true).setId("Overview");
+        book.addContent(this.getClass().getResourceAsStream("/idpflogo_web_125.jpg"),
+                "image/jpeg", "img/idpflogo_web_125.jpg", false, false);
+        book.addContent(this.getClass().getResourceAsStream("/epub-spec.css"),
+                "text/css", "css/epub-spec.css", false, false);
+        book.addTextContent("TestHtml", "xhtml/samuelTest2.xhtml", "Samuel test one two four!!!!!\nTesting two").setToc(true);
+        book.addTextContent("TestHtml", "xhtml/samuelTest.xhtml", "Samuel test one two three\nTesting two").setToc(true);
+        book.addCoverImage(IOUtils.toByteArray(this.getClass().getResourceAsStream("/P1010832.jpg")),
+                "image/jpeg", "images/P1010832.jpg");
+        return book;
     }
 }

--- a/src/test/java/coza/opencollab/epub/creator/EpubCreatorTest.java
+++ b/src/test/java/coza/opencollab/epub/creator/EpubCreatorTest.java
@@ -40,6 +40,7 @@ public class EpubCreatorTest implements WithAssertions {
         //when
         String bookOpf = unzipFileEntry(file, "content/book.opf");
         //then
+        assertThat(bookOpf).containsOnlyOnce("<meta property=\"dcterms:modified\">");
         assertThat(bookOpf).contains(String.format("<meta property=\"dcterms:modified\">%s</meta>", modified));
     }
 


### PR DESCRIPTION
Currently, the value is created automatically. This prevents being able to create a reproducible file.